### PR TITLE
Specify snapshot to rollback to

### DIFF
--- a/grub.tmpl.cfg
+++ b/grub.tmpl.cfg
@@ -28,7 +28,7 @@ set timeout=10
 {{ $build := . }}
 {{ range .Boots }}
 menuentry "{{ $build.Name }} ({{ .Title }})" {
-  linux /zfs/{{ $build.BuildID }}/vmlinuz root=zfs:{{ $storageRoot }}/{{ $build.BuildID }} bootfs.rollback zfs.force {{ range $build.Params }}{{ . }} {{ end }}{{ range .Params }}{{ . }} {{ end }}
+  linux /zfs/{{ $build.BuildID }}/vmlinuz root=zfs:{{ $storageRoot }}/{{ $build.BuildID }} bootfs.rollback=image zfs.force {{ range $build.Params }}{{ . }} {{ end }}{{ range .Params }}{{ . }} {{ end }}
   initrd /zfs/{{ $build.BuildID }}/initramfs.img
 }
 {{ end }}


### PR DESCRIPTION
In zfs 2.1.7 bug was fixed and now specifying snapshot name is possible